### PR TITLE
Multiple lines in sections (including "returns")

### DIFF
--- a/doxypypy/doxypypy.py
+++ b/doxypypy/doxypypy.py
@@ -233,6 +233,8 @@ class AstWalker(NodeVisitor):
                     if match:
                         # We've got a "returns" section
                         line = line.replace(match.group(0), ' @return\t').rstrip()
+                        line += " \parblock".format(linesep)
+                        inSection = True
                         prefix = '@return\t'
                     else:
                         match = AstWalker.__argsStartRE.match(line)

--- a/doxypypy/doxypypy.py
+++ b/doxypypy/doxypypy.py
@@ -31,7 +31,6 @@ def coroutine(func):
         return __cr
     return __start
 
-
 class AstWalker(NodeVisitor):
     """
     A walker that'll recursively progress through an AST.
@@ -223,11 +222,12 @@ class AstWalker(NodeVisitor):
                                 len(line.expandtabs(self.options.tablength).lstrip())
                             if indent <= sectionHeadingIndent:
                                 inSection = False
-                            else:
-                                if lines[-1] == '#':
-                                    # If the last line was empty, but we're still in a section
-                                    # then we need to start a new paragraph.
-                                    lines[-1] = '# @par'
+                                lines[-1] += "{0}# \endparbock".format(linesep)
+                            # else:
+                                # if lines[-1] == '#':
+                                    # # If the last line was empty, but we're still in a section
+                                    # # then we need to start a new paragraph.
+                                    # lines[-1] = '# @par'
 
                     match = AstWalker.__returnsStartRE.match(line)
                     if match:
@@ -308,6 +308,7 @@ class AstWalker(NodeVisitor):
                                                 lines[-1], inCodeBlock = self._endCodeIfNeeded(
                                                     lines[-1], inCodeBlock)
                                                 lines.append('#' + line)
+                                                lines[-1] += "{0}# \parblock".format(linesep)
                                                 continue
                                             elif prefix:
                                                 match = AstWalker.__singleListItemRE.match(line)
@@ -316,6 +317,21 @@ class AstWalker(NodeVisitor):
                                                     line = ' {0}\t{1}'.format(
                                                         prefix, match.group(0))
                                                 elif self.options.autocode and inCodeBlock:
+                                                    proseChecker.send(
+                                                        (
+                                                            line, lines,
+                                                            lineNum - firstLineNum
+                                                        )
+                                                    )
+                                                elif self.options.autocode:
+                                                    codeChecker.send(
+                                                        (
+                                                            line, lines,
+                                                            lineNum - firstLineNum
+                                                        )
+                                                    )
+                                            else:
+                                                if self.options.autocode and inCodeBlock:
                                                     proseChecker.send(
                                                         (
                                                             line, lines,


### PR DESCRIPTION
This pull request provides the following feature.

```
SomeSection:
    Description
        >>> Also with code
        >>> In multiple lines
        and output
    And now you can continue text of section
```

The same thing is now possible in "Returns" section, which provides an ability to give an examples of return values. It is important for consistency with Google Python Style Guide:
https://google.github.io/styleguide/pyguide.html#Comments

![screenshot_2017-10-12_17-47-11](https://user-images.githubusercontent.com/1962652/31502532-086f09b6-af76-11e7-9ecc-d8a7c65239ad.png)
