### PR TITLE
On blank line in code listing

### DIFF
--- a/doxypypy/doxypypy.py
+++ b/doxypypy/doxypypy.py
@@ -144,7 +144,7 @@ class AstWalker(NodeVisitor):
                         else:
                             line, lines, lineNum = (yield)
                             line = line.strip()
-                            if line.startswith('>>> '):
+                            if line.startswith('>>>'):
                                 # Definitely code, don't compile further.
                                 lineOfCode = True
                             else:

--- a/doxypypy/doxypypy.py
+++ b/doxypypy/doxypypy.py
@@ -133,7 +133,7 @@ class AstWalker(NodeVisitor):
                     line, lines, lineNum = (yield)
                     testLine = line.strip()
                     #testLineNum = 1
-                elif testLine.startswith('>>> '):
+                elif testLine.startswith('>>>'):
                     # This is definitely code.
                     lineOfCode = True
                 else:


### PR DESCRIPTION
I suggest to check for `>>>` without trailing space inside of `checkIfCode`. Usually spaces are trimmed by IDE, so it becomes impossible to provide a blank line inside of code listing.