### PR TITLE
Adding basic RST support to doxypypy

### DIFF
--- a/doxypypy/doxypypy.py
+++ b/doxypypy/doxypypy.py
@@ -875,7 +875,8 @@ class AstWalker(NodeVisitor):
         if get_docstring(node):
             last_doc_line_number = self._processDocstring(node, tail,
                                    containingNodes=containingNodes)
-            #self._shift_decorators_below_docstring(node, last_doc_line_number)
+            if self.args.keepDecorators:
+                self._shift_decorators_below_docstring(node, last_doc_line_number)
 
         # Visit any contained nodes.
         self.generic_visit(node, containingNodes=containingNodes)
@@ -935,7 +936,8 @@ class AstWalker(NodeVisitor):
         if get_docstring(node):
             last_doc_line_number = self._processDocstring(node, contextTag,
                                    containingNodes=containingNodes)
-            #self._shift_decorators_below_docstring(node, last_doc_line_number)
+            if self.args.keepDecorators:
+                self._shift_decorators_below_docstring(node, last_doc_line_number)
         # Visit any contained nodes.
         self.generic_visit(node, containingNodes=containingNodes)
         # Remove the item we pushed onto the containing nodes hierarchy.
@@ -1035,6 +1037,12 @@ def main():
             "-e","--equalIndent",
             action="store_true", dest="equalIndent",
             help="Make indention level of docstrings matching with their enclosing definitions one."
+        )
+        parser.add_argument(
+            "-k","--keepDecorators",
+            action="store_true", dest="keepDecorators",
+            help="Decorators are usually ignored by doxypypy and thus are before the doxygen docString output and not before it's definition string."
+                 "With this option decorators are kept before it's definition string (function or class names). But this requires dogygen 1.9 or higher."
         )
         group = parser.add_argument_group("Debug Options")
         group.add_argument(

--- a/doxypypy/doxypypy.py
+++ b/doxypypy/doxypypy.py
@@ -100,6 +100,20 @@ class AstWalker(NodeVisitor):
     __errorLineRE = regexpCompile(r"^\s*((?:\S+Error|Traceback.*):?\s*(.*)|@?[\w.]+)\s*$",
                                   IGNORECASE)
 
+    # searching for reStructuredText field lists
+    #__rst_paramRE = regexpCompile(r"^\s*(?::param(eter)?|:arg(ument)?|:key(word)?)"
+    #                              r"\s*(\w*)\s*(\w*)\s*:(.*)") # search for :param, :parameter, :arg, :argument, :key, :keyword
+                                  # this searches for the keyword and the colons, but returns all in between as one group:
+    __rst_paramRE = regexpCompile(r"^\s*(?::param(eter)?|:arg(ument)?|:key(word)?)([^:]*):\s*(.*)")
+    __rst_typeRE = regexpCompile(r"^(\s*)(?::type)"
+                                  r"\s*(\w*)\s*:(.*)")   # search for :type
+    __rst_rtypeRE = regexpCompile(r"^(\s*)(?::rtype)\s*(.*):(.*)") # search for rtype
+    __rst_returnRE = regexpCompile(r"^\s*(?::return)\s*(.*): (.*)$")
+    __rst_literal_sectionRE = regexpCompile(r"^(.*)::$")
+    __rst_tableRE = regexpCompile(r"^\s*=+\s+(=+\s*)+$") # end of table is a blank line
+
+    __LITERAL_SECTION_MARK = "~~~~~~"
+
     def __init__(self, lines, arguments):
         """Initialize a few class variables in preparation for our walk."""
         self.lines = lines
@@ -140,6 +154,8 @@ class AstWalker(NodeVisitor):
                     # testLineNum = 1
                 elif testLine.startswith('>>>'):
                     # This is definitely code.
+                    lineOfCode = True
+                elif testLine.startswith('...'):
                     lineOfCode = True
                 else:
                     try:
@@ -190,14 +206,20 @@ class AstWalker(NodeVisitor):
         """
         assert isinstance(tail, str) and isinstance(writer, GeneratorType)
 
-        lines = []
+        lines = [] # get's filled with changed line data until it is written out again
         timeToSend = False
-        inCodeBlock = False
-        inCodeBlockObj = [False]
+        inCodeBlock = False      # local CodeBlock state
+        inCodeBlockObj = [False] # codeChecker CodeBlock state
         inSection = False
+        in_literal_section = False
+        in_rst_table = False
+        rst_table_start_line_number = -1
+        table_count = 0
+        rst_table_middle_column_positions = [] # first and last column are line dependent ...
         prefix = ''
         firstLineNum = -1
         sectionHeadingIndent = 0
+        docstringIndent = 0
         codeChecker = self._checkIfCode(inCodeBlockObj)
         while True:
             lineNum, line = (yield)
@@ -220,7 +242,8 @@ class AstWalker(NodeVisitor):
                             firstLineNum = lineNum
                             line = line.replace(match.group(1), doxyTag)
                             timeToSend = True
-
+                            
+                    # Special Line Mode handlings:
                     if inSection:
                         # The last line belonged to a section.
                         # Does this one too? (Ignoring empty lines.)
@@ -235,6 +258,56 @@ class AstWalker(NodeVisitor):
                                     # If the last line was empty, but we're still in a section
                                     # then we need to start a new paragraph.
                                     lines[-1] = '# @par'
+                    elif in_literal_section:
+                        # currently there's a literal section active
+                        match = AstWalker.__blanklineRE.match(line)
+                        if not match:
+                            # evaluate only non blank lines
+                            current_indent = len(line.expandtabs(self.args.tablength)) \
+                                              - len(line.expandtabs(self.args.tablength).lstrip())
+                            if current_indent > sectionHeadingIndent:
+                                # just use it unchanged, but ensure it is at least 4 spaces indented
+                                #doxygen only evaluates relative indents to former indent level
+                                if (current_indent - sectionHeadingIndent) < 4:
+                                    extra_indent = " " * (4 - current_indent + sectionHeadingIndent)
+                                else:
+                                    extra_indent = ''
+                                lines.append("#" + extra_indent + line)
+                                continue
+                            else:
+                                in_literal_section = False
+                                #line = line.rstrip() + "Le"
+                                #lines.append("#" + AstWalker.__LITERAL_SECTION_MARK) # fencing requires line addition -> which is not yet supported here
+                    elif in_rst_table:
+                        # end table on a blank line
+                        match = AstWalker.__blanklineRE.match(line)
+                        if match:
+                            in_rst_table = False
+                            lines.append ("#" + line)
+                            continue
+                        # check for intermediate border lines -> doxygen only knows them at second table line as separator line ...
+                        match = AstWalker.__rst_tableRE.match(line)
+                        if match:
+                            if rst_table_start_line_number + 2 == lineNum:
+                                line = line.replace("=","-")
+                            else:
+                                #line = line.replace("="," ") # white spaces will end the table ... so use
+                                # replace every starting = with - and all following with ' '
+                                line = line.replace (" =", " -")
+                                line = line.replace ("=", " ")
+
+                        # insert pipes before first text and behind last text ... well not always needed so skip it for now
+
+                        # insert pipes on all middle positions, check if there's a whitespace there
+                        for pos in rst_table_middle_column_positions:
+                            if line[pos] == ' ':
+                                line = line[:pos] + '|' + line[pos + 1:]
+                            #else:
+                                # well miss formated simple rst table
+                                # -> let the garbage flow ... until next blank line ...
+                                # Note: multiline rst table cells are not translateable to simple Markdown ...
+                        lines.append("#"+ line)
+                        continue # no further translation needed here
 
                     match = AstWalker.__returnsStartRE.match(line)
                     if match:
@@ -253,97 +326,159 @@ class AstWalker(NodeVisitor):
                                 prefix = '@property\t'
                             else:
                                 prefix = '@param\t'
-                            lines[-1], inCodeBlock = self._endCodeIfNeeded(
+                            if len(lines) > 0: lines[-1], inCodeBlock = self._endCodeIfNeeded(
                                 lines[-1], inCodeBlock)
                             inCodeBlockObj[0] = inCodeBlock
                             lines.append('#' + line)
                             continue
-                        match = AstWalker.__argsRE.match(line)
-                        if match and not inCodeBlock:
-                            # We've got something that looks like an item /
-                            # description pair.
-                            if 'property' in prefix:
-                                line = '# {0}\t{1[name]}{2}# {1[desc]}'.format(
-                                    prefix, match.groupdict(), linesep)
-                            else:
-                                line = ' {0}\t{1[name]}\t{1[desc]}'.format(
-                                    prefix, match.groupdict())
                         else:
-                            match = AstWalker.__raisesStartRE.match(line)
+
+                            match = AstWalker.__rst_paramRE.match(line)
                             if match:
-                                line = line.replace(match.group(0), '').rstrip()
-                                if 'see' in match.group(1).lower():
-                                    # We've got a "see also" section
-                                    prefix = '@sa\t'
-                                else:
-                                    # We've got an "exceptions" section
-                                    prefix = '@exception\t'
-                                lines[-1], inCodeBlock = self._endCodeIfNeeded(
+                                # it's an rst param
+                                # last word is the param name
+                                param_declarations = match.group(4).rpartition(' ')
+                                line = f"{param_declarations[2]} {param_declarations[0]} {param_declarations[1]} {match.group(5)}"
+
+                                prefix = '@param\t'
+                                if len(lines) > 0: lines[-1], inCodeBlock = self._endCodeIfNeeded(
                                     lines[-1], inCodeBlock)
-                                inCodeBlockObj[0] = inCodeBlock
+                                lines.append('#@param\t' + line)
+                                continue # line is processed
+
+                            match = AstWalker.__rst_typeRE.match(line)
+                            if match:
+                                # it's a type description to a former param
+                                line = f"{match.group(1)}@n type of {match.group(2)}: {match.group(3)}" #@n = newline
+                                if len(lines) > 0: lines[-1], inCodeBlock = self._endCodeIfNeeded(
+                                    lines[-1], inCodeBlock)
                                 lines.append('#' + line)
-                                continue
-                            match = AstWalker.__listRE.match(line)
+                                continue # line is processed
+
+                            match = AstWalker.__rst_returnRE.match(line)
+                            if match:
+                                # it's a return description line
+                                prefix = "@return\t"
+                                line = f"@return {match.group(1)} {match.group(2)}"
+                                if len(lines) > 0: lines[-1], inCodeBlock = self._endCodeIfNeeded(
+                                    lines[-1], inCodeBlock)
+                                lines.append('#' + line)
+                                continue # line is processed
+
+                            match = AstWalker.__rst_rtypeRE.match(line)
+                            if match:
+                                # it's a return type description to a former return
+                                line = f"{match.group(1)}@n return type of {match.group(2)}: {match.group(3)}" #@n = newline
+                                if len(lines) > 0: lines[-1], inCodeBlock = self._endCodeIfNeeded(
+                                    lines[-1], inCodeBlock)
+                                lines.append('#' + line)
+                                continue # line is processed
+
+                            match = AstWalker.__rst_tableRE.match(line)
+                            if match:
+                                # found a rst table start
+                                in_rst_table = True
+                                current_indent = len(line.expandtabs(self.args.tablength)) \
+                                              - len(line.expandtabs(self.args.tablength).lstrip())
+                                rst_table_start_line_number = lineNum
+                                #get the positions of middle columns
+                                rst_table_middle_column_positions = []
+                                pos = line.find("= ")
+                                while (pos != -1):
+                                    rst_table_middle_column_positions.append(pos + 1) # the space is after =
+                                    pos = line.find("= ",pos+1)
+                                #other code detectors need to be run here to get out of their mode but keep line indention for not triggering a literal section!
+                                table_count += 1
+                                line = " " * current_indent + f"Table {table_count}" # <text> number prevents singleListItem detection later
+
+
+                            match = AstWalker.__argsRE.match(line)
                             if match and not inCodeBlock:
-                                # We've got a list of something or another
-                                itemList = []
-                                for itemMatch in AstWalker.__listItemRE.findall(self._stripOutAnds(
-                                                                                match.group(0))):
-                                    itemList.append('# {0}\t{1}{2}'.format(
-                                        prefix, itemMatch, linesep))
-                                line = ''.join(itemList)[1:]
-                            else:
-                                match = AstWalker.__examplesStartRE.match(line)
-                                if match and lines[-1].strip() == '#' \
-                                   and self.args.autocode:
-                                    # We've got an "example" section
-                                    inCodeBlock = True
-                                    inCodeBlockObj[0] = True
-                                    line = line.replace(match.group(0),
-                                                        ' @b Examples{0}# @code'.format(linesep))
+                                # We've got something that looks like an item /
+                                # description pair.
+                                if 'property' in prefix:
+                                    line = '# {0}\t{1[name]}{2}# {1[desc]}'.format(
+                                        prefix, match.groupdict(), linesep)
                                 else:
-                                    match = AstWalker.__sectionStartRE.match(line)
-                                    if match:
-                                        # We've got an arbitrary section
-                                        prefix = ''
-                                        inSection = True
-                                        # What's the indentation of the section heading?
-                                        sectionHeadingIndent = len(line.expandtabs(self.args.tablength)) \
-                                            - len(line.expandtabs(self.args.tablength).lstrip())
-                                        line = line.replace(
-                                            match.group(0),
-                                            ' @par {0}'.format(match.group(1))
-                                        )
-                                        if lines[-1] == '# @par':
-                                            lines[-1] = '#'
-                                        lines[-1], inCodeBlock = self._endCodeIfNeeded(
-                                            lines[-1], inCodeBlock)
-                                        inCodeBlockObj[0] = inCodeBlock
-                                        lines.append('#' + line)
-                                        continue
-                                    if prefix:
-                                        match = AstWalker.__singleListItemRE.match(line)
-                                        if match and not inCodeBlock:
-                                            # Probably a single list item
-                                            line = ' {0}\t{1}'.format(
-                                                prefix, match.group(0))
-                                        elif self.args.autocode:
-                                            codeChecker.send(
-                                                (
-                                                    line, lines,
-                                                    lineNum - firstLineNum
-                                                )
-                                            )
-                                            inCodeBlock = inCodeBlockObj[0]
+                                    line = ' {0}\t{1[name]}\t{1[desc]}'.format(
+                                        prefix, match.groupdict())
+                            else:
+                                match = AstWalker.__raisesStartRE.match(line)
+                                if match:
+                                    line = line.replace(match.group(0), '').rstrip()
+                                    if 'see' in match.group(1).lower():
+                                        # We've got a "see also" section
+                                        prefix = '@sa\t'
                                     else:
-                                        if self.args.autocode:
-                                            codeChecker.send(
-                                                (
-                                                    line, lines,
-                                                    lineNum - firstLineNum
+                                        # We've got an "exceptions" section
+                                        prefix = '@exception\t'
+                                    lines[-1], inCodeBlock = self._endCodeIfNeeded(
+                                        lines[-1], inCodeBlock)
+                                    inCodeBlockObj[0] = inCodeBlock
+                                    lines.append('#' + line)
+                                    continue
+                                else:
+                                    match = AstWalker.__listRE.match(line)
+                                    if match and not inCodeBlock:
+                                        # We've got a list of something or another
+                                        itemList = []
+                                        for itemMatch in AstWalker.__listItemRE.findall(self._stripOutAnds(
+                                                                                        match.group(0))):
+                                            itemList.append('# {0}\t{1}{2}'.format(
+                                                prefix, itemMatch, linesep))
+                                        line = ''.join(itemList)[1:]
+                                    else:
+                                        match = AstWalker.__examplesStartRE.match(line)
+                                        if match and lines[-1].strip() == '#' \
+                                           and self.args.autocode:
+                                            # We've got an "example" section
+                                            inCodeBlock = True
+                                            inCodeBlockObj[0] = True
+                                            line = line.replace(match.group(0),
+                                                                ' @b Examples{0}# @code'.format(linesep))
+                                        else:
+                                            match = AstWalker.__sectionStartRE.match(line)
+                                            if match:
+                                                # We've got an arbitrary section
+                                                prefix = ''
+                                                inSection = True
+                                                # What's the indentation of the section heading?
+                                                sectionHeadingIndent = len(line.expandtabs(self.args.tablength)) \
+                                                    - len(line.expandtabs(self.args.tablength).lstrip())
+                                                line = line.replace(
+                                                    match.group(0),
+                                                    ' @par {0}'.format(match.group(1))
                                                 )
-                                            )
-                                            inCodeBlock = inCodeBlockObj[0]
+                                                if lines[-1] == '# @par':
+                                                    lines[-1] = '#'
+                                                lines[-1], inCodeBlock = self._endCodeIfNeeded(
+                                                    lines[-1], inCodeBlock)
+                                                inCodeBlockObj[0] = inCodeBlock
+                                                lines.append('#' + line)
+                                                continue
+                                            elif prefix:
+                                                match = AstWalker.__singleListItemRE.match(line)
+                                                if match and not inCodeBlock:
+                                                    # Probably a single list item
+                                                    line = ' {0}\t{1}'.format(
+                                                        prefix, match.group(0))
+                                                elif self.args.autocode:
+                                                    codeChecker.send(
+                                                        (
+                                                            line, lines,
+                                                            lineNum - firstLineNum
+                                                        )
+                                                    )
+                                                    inCodeBlock = inCodeBlockObj[0]
+                                            else:
+                                                if self.args.autocode:
+                                                    codeChecker.send(
+                                                        (
+                                                            line, lines,
+                                                            lineNum - firstLineNum
+                                                        )
+                                                    )
+                                                    inCodeBlock = inCodeBlockObj[0]
 
                 # If we were passed a tail, append it to the docstring.
                 # Note that this means that we need a docstring for this
@@ -363,12 +498,13 @@ class AstWalker(NodeVisitor):
                 timeToSend = True
 
             if timeToSend:
-                lines[-1], inCodeBlock = self._endCodeIfNeeded(lines[-1],
+                if len(lines) > 0: lines[-1], inCodeBlock = self._endCodeIfNeeded(lines[-1],
                                                                inCodeBlock)
                 inCodeBlockObj[0] = inCodeBlock
                 writer.send((firstLineNum, lineNum, lines))
                 lines = []
                 firstLineNum = -1
+                table_count = 0
                 timeToSend = False
 
     @coroutine
@@ -393,6 +529,8 @@ class AstWalker(NodeVisitor):
 
         Basically just figures out the bounds of the docstring and sends it
         off to the parser to do the actual work.
+
+        Return: last line number of this docstring
         """
         typeName = type(node).__name__
         # Modules don't have lineno defined, but it's always 0 for them.
@@ -439,6 +577,7 @@ class AstWalker(NodeVisitor):
             docstringConverter.send((len(self.docLines) - 1, None))
 
         # Add a Doxygen @brief tag to any single-line description.
+        # but take care not to remove the initial '##' doxygen marker        
         if self.args.autobrief:
             safetyCounter = 0
             while len(self.docLines) > 0 and self.docLines[0].lstrip('#').strip() == '':
@@ -454,13 +593,29 @@ class AstWalker(NodeVisitor):
                 self.docLines[0] = "## @brief {0}".format(self.docLines[0].lstrip('#'))
                 if len(self.docLines) > 1 and self.docLines[1] == '# @par':
                     self.docLines[1] = '#'
+            # safety catch up for starting with doxygen marker even if first DocString Line is empty
+            # and has been removed in former processings for autobrief
+            if safetyCounter > 0 and not self.docLines[0].lstrip().startswith('##'):
+                self.docLines[0] = '##' + self.docLines[0]
 
         if defLines:
+            # make all docstring comments on same indentation as their enclosing object's indention level
+            # but remove this added indent within the docstring if needed
             match = AstWalker.__indentRE.match(defLines[0])
             indentStr = match.group(1) if match else ''
             self.docLines = [AstWalker.__newlineRE.sub(indentStr + '#', docLine)
                              for docLine in self.docLines]
-
+            if self.args.equalIndent and len(indentStr) > 0:
+                # remove the same amount of indent within the docLine part
+                indentPartRE = regexpCompile(f"{indentStr}#+({indentStr})")
+                for (index,docLine) in enumerate(self.docLines):
+                    docIndentPart = indentPartRE.match(docLine)
+                    if docIndentPart is None:
+                        # no match
+                        continue
+                    #print (f"match line {docstringStart + index} from {docIndentPart.start(1)} to {docIndentPart.end(1)}")
+                    self.docLines[index] = docLine[:docIndentPart.start(1)] + docLine[docIndentPart.end(1):]
+        
         # Taking away a docstring from an interface method definition sometimes
         # leaves broken code as the docstring may be the only code in it.
         # Here we manually insert a pass statement to rectify this problem.
@@ -475,7 +630,8 @@ class AstWalker(NodeVisitor):
             parentType = fullPathNamespace[-2][1]
             if parentType == 'interface' and typeName == 'FunctionDef' \
                or fullPathNamespace[-1][1] == 'interface':
-                defLines[-1] = '{0}{1}{2}pass'.format(defLines[-1],
+                # defLines should always end with some kind of new line -> insert two os correct ones                
+                defLines[-1] = '{0}{1}{1}{2}pass'.format(defLines[-1].rstrip(),
                                                       linesep, indentStr)
             elif self.args.autobrief and typeName == 'ClassDef':
                 # If we're parsing docstrings separate out class attribute
@@ -505,7 +661,7 @@ class AstWalker(NodeVisitor):
                         self.docLines[firstVarLineNum: lastVarLineNum] = []
                         # After the property shuffling we will need to relocate
                         # any existing namespace information.
-                        namespaceLoc = defLines[-1].find('\n# @namespace')
+                        namespaceLoc = defLines[-1].find(linesep+'# @namespace')
                         if namespaceLoc >= 0:
                             self.docLines[-1] += defLines[-1][namespaceLoc:]
                             defLines[-1] = defLines[-1][:namespaceLoc]
@@ -517,6 +673,7 @@ class AstWalker(NodeVisitor):
             self.lines[startLineNum: endLineNum] = self.docLines + defLines
         else:
             self.lines[startLineNum: endLineNum] = defLines + self.docLines
+        return endLineNum
 
     @staticmethod
     def _checkMemberName(name):
@@ -716,8 +873,10 @@ class AstWalker(NodeVisitor):
         else:
             tail = self._processMembers(node, '')
         if get_docstring(node):
-            self._processDocstring(node, tail,
+            last_doc_line_number = self._processDocstring(node, tail,
                                    containingNodes=containingNodes)
+            #self._shift_decorators_below_docstring(node, last_doc_line_number)
+
         # Visit any contained nodes.
         self.generic_visit(node, containingNodes=containingNodes)
         # Remove the item we pushed onto the containing nodes hierarchy.
@@ -774,8 +933,9 @@ class AstWalker(NodeVisitor):
             contextTag = tail
         contextTag = self._processMembers(node, contextTag)
         if get_docstring(node):
-            self._processDocstring(node, contextTag,
+            last_doc_line_number = self._processDocstring(node, contextTag,
                                    containingNodes=containingNodes)
+            #self._shift_decorators_below_docstring(node, last_doc_line_number)
         # Visit any contained nodes.
         self.generic_visit(node, containingNodes=containingNodes)
         # Remove the item we pushed onto the containing nodes hierarchy.
@@ -788,7 +948,19 @@ class AstWalker(NodeVisitor):
     def visit_Constant(self, node, **kwargs):
         """Handle constant definitions within code."""
         super().visit_Constant(node)
-
+    
+    def _shift_decorators_below_docstring (self, node, last_doc_line_number):
+        if node.decorator_list:
+            # get the decorators of this function and put them after DocString -> needs doxygen 1.9 or higher
+            # as decorators must be one line before function name, restructuring should be possible
+            #print (str(node.decorator_list) + str(node.decorator_list[0].id) + str(node.decorator_list[0].lineno))
+            for decorator in node.decorator_list:
+                # first in list is last decorator called ... -> thus first line with decorator
+                org_line_number = decorator.lineno - 1
+                new_line_number = last_doc_line_number - 1
+                self.lines[org_line_number:new_line_number] = self.lines[org_line_number + 1 :new_line_number] + [self.lines[org_line_number]]
+                pass
+    
     def parseLines(self):
         """Form an AST for the code and produce a new version of the source."""
         inAst = parse(''.join(self.lines), self.args.filename)
@@ -797,6 +969,8 @@ class AstWalker(NodeVisitor):
 
     def getLines(self):
         """Return the modified file once processing has been completed."""
+        # Note: some processing steps insert new lines within one lines.line ...
+        # so actually all lineseps need to be replaced within one line, even in the middle of a line ...
         return linesep.join(line.rstrip() for line in self.lines)
 
 
@@ -856,6 +1030,11 @@ def main():
             help="By default, doxypypy hides object class from class dependencies"
                  "even if class inherits explictilty from objects (new-style class),"
                  "this option disable this."
+        )
+        parser.add_argument(
+            "-e","--equalIndent",
+            action="store_true", dest="equalIndent",
+            help="Make indention level of docstrings matching with their enclosing definitions one."
         )
         group = parser.add_argument_group("Debug Options")
         group.add_argument(

--- a/doxypypy/test/sample_rstexample.out.py
+++ b/doxypypy/test/sample_rstexample.out.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+## @brief Test some restrucutred Text docstrings.
+#
+#It should process them into valid doxygen tags and formatings.
+#
+# @namespace sample_rstexample
+
+
+import sys
+
+## @brief     ExampleClass just for testing rst docstrings.
+#
+#    It's meant to be processed as regular text.
+#
+#        with literal code section
+#           which is just        treated as is.
+#           by doxygen.
+#        until it ends on former paragraph indent.
+#
+#    Here is a new regular text.
+#
+#
+# @namespace sample_rstexample.ExampleClass
+
+class ExampleClass:
+    ## @brief          Just inits a ExampleClass object.
+    #
+    # @namespace sample_rstexample.ExampleClass.__init__
+
+    def __init__(self):
+        self.member = "Value"
+
+    ## @brief         And here is a typical method.
+    #
+    #        With parameters
+    #
+    #@param	new    Which holds some random string.
+    #        @n type of new:  str
+    #@param	other    For random number input
+    #        @n type of other:  int
+    #@param	yet_another    Yet another number for input.
+    #        @n type of yet_another:  int, optional paramter, Default = 0
+    #
+    #@return  Just some result as example number
+    #        @n return type of :  int
+    #
+    # @namespace sample_rstexample.ExampleClass.methodExample
+
+    def methodExample(self, new : str, other: int, yet_another : int = 0) -> int:
+        self.member = "NewValue" + new
+        return 2 + other
+
+
+## @brief     This function should work even on module level.
+#
+#@param	arg  [in]   <int> Some thingumabob to this function. with alternative type description.
+#@return  Nothing
+#
+#    But describe a table of other things.
+#
+#    Table 1
+#     With entries  |    Heads |     Cols
+#    ---------------| ---------|   --------
+#      1. Entry     |   Big    |     First
+#      2. Entry     |  Smaller |     Third
+#      3. Entry     |  Rare    |      Even
+#    -              | -        |   -
+#
+#    And other textes too.
+#
+# @namespace sample_rstexample.generic_function
+
+def generic_function(arg : int):
+    print(arg)
+    a = arg
+    arg = a
+
+

--- a/doxypypy/test/sample_rstexample.outbare.py
+++ b/doxypypy/test/sample_rstexample.outbare.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+##
+#Test some restrucutred Text docstrings.
+#
+#It should process them into valid doxygen tags and formatings.
+#
+
+import sys
+
+##
+#    ExampleClass just for testing rst docstrings.
+#
+#    It's meant to be processed as regular text.
+#
+#        with literal code section
+#           which is just        treated as is.
+#           by doxygen.
+#        until it ends on former paragraph indent.
+#
+#    Here is a new regular text.
+#
+#
+class ExampleClass:
+    ##
+    #         Just inits a ExampleClass object.
+    #
+    def __init__(self):
+        self.member = "Value"
+
+    ##
+    #        And here is a typical method.
+    #
+    #        With parameters
+    #
+    #        :param new: Which holds some random string.
+    #        :type new: str
+    #        :param other: For random number input
+    #        :type other: int
+    #        :param yet_another: Yet another number for input.
+    #        :type yet_another: int, optional paramter, Default = 0
+    #
+    #        :return: Just some result as example number
+    #        :rtype: int
+    #
+    def methodExample(self, new : str, other: int, yet_another : int = 0) -> int:
+        self.member = "NewValue" + new
+        return 2 + other
+
+
+##
+#    This function should work even on module level.
+#
+#    :param [in] arg: <int> Some thingumabob to this function. with alternative type description.
+#    :return: Nothing
+#
+#    But describe a table of other things.
+#
+#    ===============  =========    ========
+#     With entries       Heads       Cols
+#    ===============  =========    ========
+#      1. Entry         Big          First
+#      2. Entry        Smaller       Third
+#      3. Entry        Rare           Even
+#    ===============  =========    ========
+#
+#    And other textes too.
+#
+def generic_function(arg : int):
+    print(arg)
+    a = arg
+    arg = a
+
+

--- a/doxypypy/test/sample_rstexample.outeq.py
+++ b/doxypypy/test/sample_rstexample.outeq.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+## @brief Test some restrucutred Text docstrings.
+#
+#It should process them into valid doxygen tags and formatings.
+#
+
+
+import sys
+
+## @brief     ExampleClass just for testing rst docstrings.
+#
+#    It's meant to be processed as regular text.
+#
+#        with literal code section
+#           which is just        treated as is.
+#           by doxygen.
+#        until it ends on former paragraph indent.
+#
+#    Here is a new regular text.
+#
+#
+
+class ExampleClass:
+    ## @brief          Just inits a ExampleClass object.
+    #
+
+    def __init__(self):
+        self.member = "Value"
+
+    ## @brief         And here is a typical method.
+    #
+    #    With parameters
+    #
+    #@param	new    Which holds some random string.
+    #    @n type of new:  str
+    #@param	other    For random number input
+    #    @n type of other:  int
+    #@param	yet_another    Yet another number for input.
+    #    @n type of yet_another:  int, optional paramter, Default = 0
+    #
+    #@return  Just some result as example number
+    #    @n return type of :  int
+    #
+
+    def methodExample(self, new : str, other: int, yet_another : int = 0) -> int:
+        self.member = "NewValue" + new
+        return 2 + other
+
+
+## @brief     This function should work even on module level.
+#
+#@param	arg  [in]   <int> Some thingumabob to this function. with alternative type description.
+#@return  Nothing
+#
+#    But describe a table of other things.
+#
+#    Table 1
+#     With entries  |    Heads |     Cols
+#    ---------------| ---------|   --------
+#      1. Entry     |   Big    |     First
+#      2. Entry     |  Smaller |     Third
+#      3. Entry     |  Rare    |      Even
+#    -              | -        |   -
+#
+#    And other textes too.
+#
+
+def generic_function(arg : int):
+    print(arg)
+    a = arg
+    arg = a
+
+

--- a/doxypypy/test/sample_rstexample.outnc.py
+++ b/doxypypy/test/sample_rstexample.outnc.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+## @brief Test some restrucutred Text docstrings.
+#
+#It should process them into valid doxygen tags and formatings.
+#
+# @namespace sample_rstexample
+
+
+import sys
+
+## @brief     ExampleClass just for testing rst docstrings.
+#
+#    It's meant to be processed as regular text.
+#
+#        with literal code section
+#           which is just        treated as is.
+#           by doxygen.
+#        until it ends on former paragraph indent.
+#
+#    Here is a new regular text.
+#
+#
+# @namespace sample_rstexample.ExampleClass
+
+class ExampleClass:
+    ## @brief          Just inits a ExampleClass object.
+    #
+    # @namespace sample_rstexample.ExampleClass.__init__
+
+    def __init__(self):
+        self.member = "Value"
+
+    ## @brief         And here is a typical method.
+    #
+    #        With parameters
+    #
+    #@param	new    Which holds some random string.
+    #        @n type of new:  str
+    #@param	other    For random number input
+    #        @n type of other:  int
+    #@param	yet_another    Yet another number for input.
+    #        @n type of yet_another:  int, optional paramter, Default = 0
+    #
+    #@return  Just some result as example number
+    #        @n return type of :  int
+    #
+    # @namespace sample_rstexample.ExampleClass.methodExample
+
+    def methodExample(self, new : str, other: int, yet_another : int = 0) -> int:
+        self.member = "NewValue" + new
+        return 2 + other
+
+
+## @brief     This function should work even on module level.
+#
+#@param	arg  [in]   <int> Some thingumabob to this function. with alternative type description.
+#@return  Nothing
+#
+#    But describe a table of other things.
+#
+#    Table 1
+#     With entries  |    Heads |     Cols
+#    ---------------| ---------|   --------
+#      1. Entry     |   Big    |     First
+#      2. Entry     |  Smaller |     Third
+#      3. Entry     |  Rare    |      Even
+#    -              | -        |   -
+#
+#    And other textes too.
+#
+# @namespace sample_rstexample.generic_function
+
+def generic_function(arg : int):
+    print(arg)
+    a = arg
+    arg = a
+
+

--- a/doxypypy/test/sample_rstexample.outnn.py
+++ b/doxypypy/test/sample_rstexample.outnn.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+## @brief Test some restrucutred Text docstrings.
+#
+#It should process them into valid doxygen tags and formatings.
+#
+
+
+import sys
+
+## @brief     ExampleClass just for testing rst docstrings.
+#
+#    It's meant to be processed as regular text.
+#
+#        with literal code section
+#           which is just        treated as is.
+#           by doxygen.
+#        until it ends on former paragraph indent.
+#
+#    Here is a new regular text.
+#
+#
+
+class ExampleClass:
+    ## @brief          Just inits a ExampleClass object.
+    #
+
+    def __init__(self):
+        self.member = "Value"
+
+    ## @brief         And here is a typical method.
+    #
+    #        With parameters
+    #
+    #@param	new    Which holds some random string.
+    #        @n type of new:  str
+    #@param	other    For random number input
+    #        @n type of other:  int
+    #@param	yet_another    Yet another number for input.
+    #        @n type of yet_another:  int, optional paramter, Default = 0
+    #
+    #@return  Just some result as example number
+    #        @n return type of :  int
+    #
+
+    def methodExample(self, new : str, other: int, yet_another : int = 0) -> int:
+        self.member = "NewValue" + new
+        return 2 + other
+
+
+## @brief     This function should work even on module level.
+#
+#@param	arg  [in]   <int> Some thingumabob to this function. with alternative type description.
+#@return  Nothing
+#
+#    But describe a table of other things.
+#
+#    Table 1
+#     With entries  |    Heads |     Cols
+#    ---------------| ---------|   --------
+#      1. Entry     |   Big    |     First
+#      2. Entry     |  Smaller |     Third
+#      3. Entry     |  Rare    |      Even
+#    -              | -        |   -
+#
+#    And other textes too.
+#
+
+def generic_function(arg : int):
+    print(arg)
+    a = arg
+    arg = a
+
+

--- a/doxypypy/test/sample_rstexample.py
+++ b/doxypypy/test/sample_rstexample.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Test some restrucutred Text docstrings.
+
+It should process them into valid doxygen tags and formatings.
+"""
+
+import sys
+
+class ExampleClass:
+    """
+    ExampleClass just for testing rst docstrings.
+    
+    It's meant to be processed as regular text.
+    
+        with literal code section
+           which is just        treated as is.
+           by doxygen.
+        until it ends on former paragraph indent.
+    
+    Here is a new regular text.
+    
+    """
+    def __init__(self):
+        """
+         Just inits a ExampleClass object.
+        """
+        self.member = "Value"
+        
+    def methodExample(self, new : str, other: int, yet_another : int = 0) -> int:
+        """
+        And here is a typical method.
+        
+        With parameters
+        
+        :param new: Which holds some random string.
+        :type new: str       
+        :param other: For random number input
+        :type other: int
+        :param yet_another: Yet another number for input.
+        :type yet_another: int, optional paramter, Default = 0
+        
+        :return: Just some result as example number
+        :rtype: int
+        """
+        self.member = "NewValue" + new
+        return 2 + other
+        
+
+def generic_function(arg : int):
+    """
+    This function should work even on module level.
+    
+    :param [in] arg: <int> Some thingumabob to this function. with alternative type description.
+    :return: Nothing
+    
+    But describe a table of other things.
+    
+    ===============  =========    ========
+     With entries       Heads       Cols
+    ===============  =========    ========
+      1. Entry         Big          First
+      2. Entry        Smaller       Third
+      3. Entry        Rare           Even
+    ===============  =========    ========
+    
+    And other textes too.
+    """
+    print(arg)
+    a = arg
+    arg = a
+    
+    

--- a/doxypypy/test/test_doxypypy.py
+++ b/doxypypy/test/test_doxypypy.py
@@ -30,7 +30,8 @@ class TestDoxypypy(unittest.TestCase):
         tablength=4,
         filename='dummy.py',
         object_respect=False,
-        equalIndent=False
+        equalIndent=False,
+        keepDecorators=False
     )
     __dummySrc = [
         "print('testing: one, two, three, & four') " + linesep,
@@ -587,7 +588,8 @@ class TestDoxypypy(unittest.TestCase):
                     tablength=4,
                     filename=inFilename,
                     object_respect=False,
-                    equalIndent=equalIndent
+                    equalIndent=equalIndent,
+                    keepDecorators=False
                 )),
                 ('.outnc', Namespace(
                     autobrief=True,
@@ -598,7 +600,8 @@ class TestDoxypypy(unittest.TestCase):
                     tablength=4,
                     filename=inFilename,
                     object_respect=False,
-                    equalIndent=equalIndent
+                    equalIndent=equalIndent,
+                    keepDecorators=False
                 )),
                 ('.outnn', Namespace(
                     autobrief=True,
@@ -609,7 +612,8 @@ class TestDoxypypy(unittest.TestCase):
                     tablength=4,
                     filename=inFilename,
                     object_respect=False,
-                    equalIndent=equalIndent
+                    equalIndent=equalIndent,
+                    keepDecorators=False
                 )),
                 ('.outbare',  Namespace(
                     autobrief=False,
@@ -620,7 +624,8 @@ class TestDoxypypy(unittest.TestCase):
                     tablength=4,
                     filename=inFilename,
                     object_respect=False,
-                    equalIndent=equalIndent
+                    equalIndent=equalIndent,
+                    keepDecorators=False
                 ))
             )
         else:
@@ -633,7 +638,8 @@ class TestDoxypypy(unittest.TestCase):
                     tablength=4,
                     filename=inFilename,
                     object_respect=True,
-                    equalIndent=equalIndent
+                    equalIndent=equalIndent,
+                    keepDecorators=False
                 )),)
                 
         for options in trials:


### PR DESCRIPTION
Main change for this pull request is adding basic RST syntax support to doxygen. That way it should be possible to use standard RST Doc Strings understood by e.g. PyCharm and others. (Sphinx like Doc Strings)
With doxypypy they can be converted to a style doxygen can handle.

Besides this there are smaller additions of optional features:
* Reducing indent depth in output to a similar level original DocString have, especially in deeply
  nested DocStrings. -> option -e
* Shifting decorators back to their definition line, however this is currently still rather not yet usefull
  as long as doxygen won't integrate them into their documentation output.
  -> option -k
* line ending detection based on git checkout option (git for windows allows checkouts with linux or windows style line endings) -> only for source code based unittests

note: i'm not that used to git and git hub usage. -> Is it better to split such smaller changes on the way up into similar small pull requests?