### PR TITLE
Do not match string prefix at end of docstring

### DIFF
--- a/doxypypy/doxypypy.py
+++ b/doxypypy/doxypypy.py
@@ -56,7 +56,8 @@ class AstWalker(NodeVisitor):
     __indentRE = regexpCompile(r'^(\s*)\S')
     __newlineRE = regexpCompile(r'^#', MULTILINE)
     __blanklineRE = regexpCompile(r'^\s*$')
-    __docstrMarkerRE = regexpCompile(r"\s*([uUbB]*[rR]?(['\"]{3}))")
+    __docstrMarkerRE = regexpCompile(r"^\s*([uUbB]*[rR]?(['\"]{3}))|"
+                                     r"\s*(['\"]{3})\s*$")
     __docstrOneLineRE = regexpCompile(r"\s*[uUbB]*[rR]?(['\"]{3})(.+)\1")
 
     __implementsRE = regexpCompile(r"^(\s*)(?:zope\.)?(?:interface\.)?"


### PR DESCRIPTION
The original docstring regex removed sequences such as `r"""` from a docstring regardless if it appeared at the beginning or at the end of the docstring: `r"""Simulator"""` erroneously becomes `Simulato`. However, `r` etc. are [string prefixes](https://docs.python.org/3/reference/lexical_analysis.html#string-and-bytes-literals) and do not appear at the end of a string.

Therefore, this commit changes the regex to match string prefixes only at the beginning of the docstring and not at the end.

(Closes #84)