### PR TITLE
Add whitespace to multi-line helper text

### DIFF
--- a/doxypypy/doxypypy.py
+++ b/doxypypy/doxypypy.py
@@ -1029,22 +1029,22 @@ def main():
         parser.add_argument(
             "-O", "--object-respect",
             action="store_true", dest="object_respect",
-            help="By default, doxypypy hides object class from class dependencies"
-                 "even if class inherits explictilty from objects (new-style class),"
+            help="By default, doxypypy hides object class from class dependencies "
+                 "even if class inherits explictilty from objects (new-style class), "
                  "this option disable this."
         )
         parser.add_argument(
             "-e", "--equalIndent",
             action="store_true", dest="equalIndent",
-            help="Make indention level of docstrings matching with their enclosing"
+            help="Make indention level of docstrings matching with their enclosing "
                  "definitions one."
         )
         parser.add_argument(
             "-k", "--keepDecorators",
             action="store_true", dest="keepDecorators",
-            help="Decorators are usually ignored by doxypypy and thus are before the"
-                 "doxygen docString output and not before it's definition string."
-                 "With this option decorators are kept before it's definition string"
+            help="Decorators are usually ignored by doxypypy and thus are before the "
+                 "doxygen docString output and not before it's definition string. "
+                 "With this option decorators are kept before it's definition string "
                  "(function or class names). But this requires dogygen 1.9 or higher."
         )
         group = parser.add_argument_group("Debug Options")


### PR DESCRIPTION
Added whitespace to the multi line helper text that was missing a space between the code in multi lines For example, main branch help looks like:
  -O, --object-respect  By default, doxypypy hides object class from class dependencieseven if class inherits
                        explictilty from objects (new-style class),this option disable this.
This commit looks like:
  -O, --object-respect  By default, doxypypy hides object class from class dependencies even if class inherits
                        explictilty from objects (new-style class), this option disable this.