### PR TITLE
Add support for for loops in example section in docstrings

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -14,12 +14,10 @@ max-statements=235
 [MESSAGES CONTROL]
 disable=
 	arguments-differ,
-	bad-continuation,
 	broad-except,
 	consider-using-f-string,
 	consider-using-with,
 	invalid-name,
-	missing-super-argument,
 	no-member,
 	super-with-arguments,
 	undefined-loop-variable,

--- a/doxypypy/doxypypy.py
+++ b/doxypypy/doxypypy.py
@@ -173,9 +173,9 @@ class AstWalker(NodeVisitor):
                                 testLine += linesep + line
                                 testLine = testLine.strip()
                                 testLineNum += 1
-                    except (SyntaxError, RuntimeError):
-                        # This is definitely not code.
-                        lineOfCode = False
+                    except (SyntaxError, RuntimeError) as e:
+                        # If this is not an IndentationError, this is definitely not code.
+                        lineOfCode = isinstance(e, IndentationError)
                     except Exception:
                         # Other errors are ambiguous.
                         line, lines, lineNum = (yield)

--- a/doxypypy/test/sample_code_indent.out.py
+++ b/doxypypy/test/sample_code_indent.out.py
@@ -1,0 +1,37 @@
+## @brief Code Indentation Example
+#
+# @namespace sample_code_indent
+
+
+
+## @brief     Does nothing more than demonstrate syntax.
+#
+#    This is an example of how a Pythonic human-readable docstring can
+#    get parsed by doxypypy and marked up with Doxygen commands as a
+#    regular input filter to Doxygen.
+#
+#
+# @param		arg1	A positional argument.
+# @param		arg2	Another positional argument.
+#
+#
+# @param		kwarg	A keyword argument.
+#
+# @return
+#        A string holding the result.
+#
+#
+# @exception		ZeroDivisionError
+# @exception		AssertionError
+# @exception		ValueError.
+#
+# @b Examples
+# @code
+#        for a in range(2):
+#            print(a)
+# @endcode
+#
+# @namespace sample_code_indent.myfunction
+
+def myfunction(arg1, arg2, kwarg='whatever.'):
+    pass

--- a/doxypypy/test/sample_code_indent.outbare.py
+++ b/doxypypy/test/sample_code_indent.outbare.py
@@ -1,0 +1,31 @@
+##
+#Code Indentation Example
+#
+
+
+##
+#    Does nothing more than demonstrate syntax.
+#
+#    This is an example of how a Pythonic human-readable docstring can
+#    get parsed by doxypypy and marked up with Doxygen commands as a
+#    regular input filter to Doxygen.
+#
+#    Args:
+#        arg1:   A positional argument.
+#        arg2:   Another positional argument.
+#
+#    Kwargs:
+#        kwarg:  A keyword argument.
+#
+#    Returns:
+#        A string holding the result.
+#
+#    Raises:
+#        ZeroDivisionError, AssertionError, & ValueError.
+#
+#    Examples:
+#        for a in range(2):
+#            print(a)
+#
+def myfunction(arg1, arg2, kwarg='whatever.'):
+    pass

--- a/doxypypy/test/sample_code_indent.outnc.py
+++ b/doxypypy/test/sample_code_indent.outnc.py
@@ -1,0 +1,35 @@
+## @brief Code Indentation Example
+#
+# @namespace sample_code_indent
+
+
+
+## @brief     Does nothing more than demonstrate syntax.
+#
+#    This is an example of how a Pythonic human-readable docstring can
+#    get parsed by doxypypy and marked up with Doxygen commands as a
+#    regular input filter to Doxygen.
+#
+#
+# @param		arg1	A positional argument.
+# @param		arg2	Another positional argument.
+#
+#
+# @param		kwarg	A keyword argument.
+#
+# @return
+#        A string holding the result.
+#
+#
+# @exception		ZeroDivisionError
+# @exception		AssertionError
+# @exception		ValueError.
+#
+# @par Examples
+#        for a in range(2):
+#            print(a)
+#
+# @namespace sample_code_indent.myfunction
+
+def myfunction(arg1, arg2, kwarg='whatever.'):
+    pass

--- a/doxypypy/test/sample_code_indent.outnn.py
+++ b/doxypypy/test/sample_code_indent.outnn.py
@@ -1,0 +1,35 @@
+## @brief Code Indentation Example
+#
+
+
+
+## @brief     Does nothing more than demonstrate syntax.
+#
+#    This is an example of how a Pythonic human-readable docstring can
+#    get parsed by doxypypy and marked up with Doxygen commands as a
+#    regular input filter to Doxygen.
+#
+#
+# @param		arg1	A positional argument.
+# @param		arg2	Another positional argument.
+#
+#
+# @param		kwarg	A keyword argument.
+#
+# @return
+#        A string holding the result.
+#
+#
+# @exception		ZeroDivisionError
+# @exception		AssertionError
+# @exception		ValueError.
+#
+# @b Examples
+# @code
+#        for a in range(2):
+#            print(a)
+# @endcode
+#
+
+def myfunction(arg1, arg2, kwarg='whatever.'):
+    pass

--- a/doxypypy/test/sample_code_indent.py
+++ b/doxypypy/test/sample_code_indent.py
@@ -1,0 +1,31 @@
+"""
+Code Indentation Example
+"""
+
+
+def myfunction(arg1, arg2, kwarg='whatever.'):
+    """
+    Does nothing more than demonstrate syntax.
+
+    This is an example of how a Pythonic human-readable docstring can
+    get parsed by doxypypy and marked up with Doxygen commands as a
+    regular input filter to Doxygen.
+
+    Args:
+        arg1:   A positional argument.
+        arg2:   Another positional argument.
+
+    Kwargs:
+        kwarg:  A keyword argument.
+
+    Returns:
+        A string holding the result.
+
+    Raises:
+        ZeroDivisionError, AssertionError, & ValueError.
+
+    Examples:
+        for a in range(2):
+            print(a)
+    """
+    pass

--- a/doxypypy/test/test_doxypypy.py
+++ b/doxypypy/test/test_doxypypy.py
@@ -3,8 +3,9 @@
 """
 Tests the doxypypy filter.
 
-These tests may all be executed by running tox from the
+These tests may all be executed by running the command `tox` from the
 root level of the project.
+You can install tox with `pip install tox`
 """
 import unittest
 from argparse import Namespace
@@ -645,7 +646,7 @@ class TestDoxypypy(unittest.TestCase):
                     equalIndent=equalIndent,
                     keepDecorators=False
                 )),)
-                
+
         for options in trials:
             output = self.readAndParseFile(options[1], encoding=encoding)
             goldFilename = splitext(inFilename)[0] + options[0] + '.py'
@@ -663,6 +664,13 @@ class TestDoxypypy(unittest.TestCase):
         Test the basic example included in PEP 257.
         """
         sampleName = 'doxypypy/test/sample_pep.py'
+        self.compareAgainstGoldStandard(sampleName)
+
+    def test_code_indent(self):
+        """
+        Test the basic example included in PEP 257.
+        """
+        sampleName = 'doxypypy/test/sample_code_indent.py'
         self.compareAgainstGoldStandard(sampleName)
 
     @mark.skipif(version_info < (3, 0), reason="different behavior for Python 2")

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py310,py39,py38,py27
+envlist = py310,py312
 skip_missing_interpreters = true
 [testenv]
 # install testing framework

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py310,py312
+envlist = py38, py39,py310,py311,py312
 skip_missing_interpreters = true
 [testenv]
 # install testing framework


### PR DESCRIPTION
The main contribution is the added support for for loops in example section in docstrings.

Extra contributions are:
- update python env support: 2.7 is deprecated, add 3.11 and 3.12
- remove pylint args that are deprecated